### PR TITLE
Update minimum required PHP version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {}
+    "require": {
+        "php": ">=5.4.0",
+        "ext-pcre": "*"
+    }
 }


### PR DESCRIPTION
It is generally considered best practice to specify the minimum required PHP version in a project's `composer.json` file, as well as any necessary PHP extensions.

I searched the codebase against some lists of functions introduced at various PHP minor version releases, and discovered that the codebase here contains functions not available prior to PHP 5.4.

In both `/Adoms/src/tables/pageviews.php` and `/Adoms/wireframe/pageviews.php` (identical code block):

```PHP
			if ( php_sapi_name() !== 'cli' ) {
				if ( version_compare(phpversion(), '5.4.0', '>=') ) {
					return session_status() === PHP_SESSION_ACTIVE ? TRUE : FALSE;
				} else {
					return session_id() === '' ? FALSE : TRUE;
				}
			}
				return FALSE;
```

The function `session_status()` was [introduced with PHP 5.4](https://www.php.net/session_status) (therefore meaning that this package requires at least PHP >= 5.4).

I didn't find any other matches for functions introduced since PHP 5.4 or for any later PHP versions.

This pull request adds PHP 5.4, and also `ext-pcre` (since the codebase also uses various functions provided by PHP's regular expression engine, PCRE), as requirements to the project's `composer.json` file.
